### PR TITLE
Adding mutli-OS compatibility

### DIFF
--- a/Digital_RADs.py
+++ b/Digital_RADs.py
@@ -114,9 +114,7 @@ if enz_num == 1:
                     outfile.write(seq)
             outfile.close()
 
-            command=('rm temp')
-            p = subprocess.Popen(command, shell=True)
-            sts = os.waitpid(p.pid, 0)[1]
+            os.remove('temp')
     else:
         print('\nERROR: infile does not appear to be in fasta format')
         print('Check that first line begins with ">"\n')
@@ -195,9 +193,7 @@ elif enz_num == 2:
                     outfile.write(seq)
             outfile.close()
 
-            command=('rm temp')
-            p = subprocess.Popen(command, shell=True)
-            sts = os.waitpid(p.pid, 0)[1]
+            os.remove('temp')
     else:
         print('\nERROR: infile does not appear to be in fasta format')
         print('Check that first line begins with ">"\n')


### PR DESCRIPTION
Changed how the script removes files so it works on Windows as well as Linux.

I was working with someone who wanted to use this script and was on a Windows machine.  It was previously using a unix command to remove the temp file which caused the script to crash. in Windows  This method should just request the OS remove the script.  I tested it on Mac OSX 10.10.2, Windows 7, and Ubuntu 12.04 all with Python 2.7.X and it worked fine on all three.

Python docs if your interested: https://docs.python.org/2/library/os.html#os.remove
